### PR TITLE
ci20: serial + cgu fixes for 4.0

### DIFF
--- a/drivers/clk/jz47xx/jz47xx-cgu.c
+++ b/drivers/clk/jz47xx/jz47xx-cgu.c
@@ -384,6 +384,7 @@ static int jz47xx_clk_set_rate(struct clk_hw *hw, unsigned long req_rate,
 	unsigned long rate, flags;
 	unsigned div, i;
 	u32 reg, mask;
+	int ret = 0;
 
 	clk_info = &cgu->clock_info[jz_clk->idx];
 
@@ -422,12 +423,12 @@ static int jz47xx_clk_set_rate(struct clk_hw *hw, unsigned long req_rate,
 				mdelay(1);
 			}
 			if (i == timeout)
-				return -EBUSY;
+				ret = -EBUSY;
 		}
 
 		spin_unlock_irqrestore(&cgu->divmux_lock, flags);
 
-		return 0;
+		return ret;
 	}
 
 	return -EINVAL;

--- a/drivers/tty/serial/8250/Kconfig
+++ b/drivers/tty/serial/8250/Kconfig
@@ -346,6 +346,7 @@ config SERIAL_8250_JZ47XX
 	tristate "Support for Ingenic jz47xx series serial ports"
 	depends on SERIAL_8250
 	select SERIAL_EARLYCON
+	select SERIAL_CORE_CONSOLE
 	help
 	  If you have a system using an Ingenic jz47xx series SoC and wish to
 	  make use of its UARTs, say Y to this option. If unsure, say N.


### PR DESCRIPTION
the serial driver was rejected by gregkh due to a build error with allnoconfig that I traced to this.

squash these in
